### PR TITLE
fix: go version mismatch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.1.0

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
# Description

## Summary

During the CI runs, the Linting action failed because the Go version on the runner host did not match the version specified in the "go.mod" file. To resolve this, the actions were updated to the latest version.

## Component Affected

Specify which part of the Application is affected:

- [ ] API Schema
- [ ] Controller Logic
- [ ] Business Logic
- [ ] Configuration
- [ ] Modules / Dependencies
- [ ] Documentation
- [x] Tests
- [x] Other (describe): CI runs

## Checklist

Please confirm you have completed the following:

- [ ] I have tested these changes locally.
- [x] I verified that all new or modified files pass linting.
- [x] I verified that all tests pass successfully.
- [x] I updated or added documentation where necessary.
- [ ] I updated or added examples where necessary.
- [x] I added or updated tests where appropriate.
